### PR TITLE
Switch to nodejs4.3 runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ create-zip:
 lambda: deps env create-zip
 	aws lambda create-function --publish \
 	--function-name $(APP)-$(PROGRAM)-to-papertrail \
-	--runtime nodejs \
+	--runtime nodejs4.3 \
 	--handler index.handler \
 	--zip-file fileb://code.zip \
 	--role arn:aws:iam::$(ACCOUNT_ID):role/lambda_basic_execution

--- a/index.js
+++ b/index.js
@@ -53,12 +53,12 @@ function addAppMetrics(data, match) {
   });
 };
 
-exports.handler = function (event, context) {
+exports.handler = function (event, context, cb) {
   var payload = new Buffer(event.awslogs.data, 'base64');
 
   zlib.gunzip(payload, function (err, result) {
     if (err) {
-      return context.fail(err);
+      return cb(err);
     }
 
     dogapi.initialize({
@@ -108,13 +108,13 @@ exports.handler = function (event, context) {
 
     if (config.datadog === '') {
       log.close();
-      context.succeed();
+      return cb();
     }
 
     dogapi.metric.send_all(metricPoints, function () {
       dogapi.metric.send_all(reportPoints, function () {
         log.close();
-        context.succeed();
+        cb();
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ function addAppMetrics(data, match) {
 };
 
 exports.handler = function (event, context, cb) {
+  context.callbackWaitsForEmptyEventLoop = false;
+
   var payload = new Buffer(event.awslogs.data, 'base64');
 
   zlib.gunzip(payload, function (err, result) {


### PR DESCRIPTION
Node 0.10 is deprecated in AWS Lambda. I don't think any code changes are required, it would seem all the code is Node 4 compatible, but we do not have any tests so I cannot confirm 100%.