### PR TITLE
feat: Add a command to delete the lambda function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,7 @@ clean:
 test: env
 	docker pull lambci/lambda
 	# docker run --name lambda --rm -v $(pwd):/var/task lambci/lambda index.handler '{}'
+
+destroy:
+	aws lambda delete-function \
+	--function-name $(APP)-$(PROGRAM)-to-papertrail


### PR DESCRIPTION
`make destroy` will allow deleting the lambda function so it can be re-created to change the runtime. (https://github.com/apiaryio/cloudwatch-to-papertrail/pull/8)