### PR TITLE
added wait for flush option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LOG_GROUP ?= log_group_name
 HOST ?= logs.papertrailapp.com
 PORT ?= 1234
 DATADOG ?=
+WAIT_FOR_FLUSH ?= false
 
 ALNUM_LOG_GROUP = $(shell echo $(LOG_GROUP) | sed 's/[^[:alnum:]]/_/g')
 ACCOUNT_ID = $(shell aws sts get-caller-identity --output text --query Account)
@@ -16,7 +17,7 @@ deps:
 
 env:
 	rm -f env.json
-	echo "{\"host\": \"$(HOST)\", \"port\": $(PORT), \"appname\": \"$(APP)\", \"program\": \"$(PROGRAM)\", \"datadog\": \"$(DATADOG)\"}" > env.json
+	echo "{\"host\": \"$(HOST)\", \"port\": $(PORT), \"appname\": \"$(APP)\", \"program\": \"$(PROGRAM)\", \"datadog\": \"$(DATADOG)\", \"waitForFlush\": $(WAIT_FOR_FLUSH)}" > env.json
 
 create-zip:
 	rm -f code.zip

--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ To stream another log group to already existing lambda:
 $ export AWS_DEFAULT_REGION=us-east-1
 $ APP=helium PROGRAM=lambda LOG_GROUP=/aws/lambda/helium_compose make log
 ```
+
+By default, lambda doesn't wait for the event loop to empty before shutting down the function.
+This means logs may not be sent immediately to papertrail, but instead wait for future
+invocations.  It's also possible some logs may not get sent to papertrail at all. See
+[callbackWaitsForEmptyEventLoop](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html)
+
+To override this behavior, set `WAIT_FOR_FLUSH=true`, i.e.
+```bash
+$ APP=helium PROGRAM=lambda WAIT_FOR_FLUSH=true make deploy
+```
+
+Logs will be sent immediately to papertrail, at the expense of longer lambda execution times.

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function addAppMetrics(data, match) {
 };
 
 exports.handler = function (event, context, cb) {
-  context.callbackWaitsForEmptyEventLoop = false;
+  context.callbackWaitsForEmptyEventLoop = config.waitForFlush;
 
   var payload = new Buffer(event.awslogs.data, 'base64');
 


### PR DESCRIPTION
Spent the morning troubleshooting why my logs were never showing up in papertrail.   Turns out it's due to `context.callbackWaitsForEmptyEventLoop = false`, which meant there might be a delay before logs get sent to PT. 

This PR adds an option to shut that off for immediate logging, at the expense of longer execution times.  

Doc updates included.
