### PR TITLE
Pinning version of winston to <3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lambda to send cloudwatch logs to papertrail",
   "main": "index.js",
   "dependencies": {
-    "winston": "",
+    "winston": "<3",
     "winston-papertrail": "hyrwork/winston-papertrail",
     "dogapi": ""
   },


### PR DESCRIPTION
Winston recently updated to version 3.0. This breaks the push of data to papertrail. Pin to <3.0 and issue is resolved.