### PR TITLE
Allow dashes in log name

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ exports.handler = function (event, context, cb) {
 
     var data = JSON.parse(result.toString('utf8'));
 
-    var metricRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\ -\ info:\ ([a-z]+):.*?(metric#.*)+$/;
+    var metricRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\ -\ info:\ ([a-z-]+):.*?(metric#.*)+$/;
     var reportRegex = /^REPORT\ RequestId.*Billed\ Duration:\ ([0-9]+)\ ms.*Used:\ ([0-9]+)\ MB$/;
 
     var metricPoints = [];

--- a/test/test-datadog.js
+++ b/test/test-datadog.js
@@ -51,4 +51,33 @@ describe('data dog', function () {
       }
     ]);
   });
+
+  it('sends metrics to datadog with dashes in name', async function () {
+    const event = {
+      awslogs: {
+        data: gzipSync(JSON.stringify({
+          logEvents: [
+            {
+              message: '2018-09-17T10:31:08.433Z - info: content-encoding: metric#unencoded_size=49227 metric#encoded_size=3544 metric#tag#encoding=gzip'
+            }
+          ]
+        })).toString('base64')
+      }
+    }
+
+    await handler(event, {});
+
+    expect(metrics).to.deep.equal([
+      {
+        metric: 'app_name.default.content-encoding.unencoded_size',
+        points: [[1537180268, 49227]],
+        tags: ['encoding:gzip']
+      },
+      {
+        metric: 'app_name.default.content-encoding.encoded_size',
+        points: [[1537180268, 3544]],
+        tags: ['encoding:gzip']
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
If there are dashes in the log name, then the metrics are never sent to data dog as it doesn't match the regex.