### PR TITLE
Fix reporting to papertrail

### DIFF
--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -1,9 +1,10 @@
 const { promisify } = require('util');
 const { expect } = require('chai');
+const winston = require('winston');
 const Transport = require('winston-transport');
 const index = require('../index');
 
-const handler = promisify(index.handler);
+const handleEvent = promisify(index.handleEvent);
 
 class TestTransport extends Transport {
   constructor() {
@@ -18,16 +19,21 @@ class TestTransport extends Transport {
 }
 
 describe('#handler', function () {
+  let logger;
   let transport;
 
   beforeEach(function () {
-    index.logger.add(TestTransport);
-    transport = index.logger.transports.test;
+    logger = new winston.Logger({
+      transports: []
+    });
+    logger.add(TestTransport);
+    transport = logger.transports.test;
   });
 
   afterEach(function() {
-    index.logger.clear();
+    logger.clear();
     transport = null;
+    logger = null;
   });
 
   it('logs given awslogs to winston', async function () {
@@ -37,7 +43,7 @@ describe('#handler', function () {
       }
     }
 
-    await handler(event, {});
+    await handleEvent(event, logger);
 
     expect(transport.events).to.deep.equal([
       {


### PR DESCRIPTION
Re-using the same logger for papertrail is problematic as the logger is closed after completion and thus any further invocations of function wouldn't delivery papertrail messages.

In a previous commit (https://github.com/apiaryio/cloudwatch-to-papertrail/commit/b10a753efed2f6a7464c6c8bfdab303bf3a73c38) which altered the interface to be testable, the logger was created once which at the time I did not expect to be a problem.

This changeset refactors the handling of events to separate function which accepts a logger. The existing lambda function configures the production logger and then injects into handleEvent, the test interface works the same.